### PR TITLE
Implement Room DB

### DIFF
--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/Repository.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/Repository.kt
@@ -1,14 +1,17 @@
 package com.sandoval.bestworldrecipes.data
 
+import com.sandoval.bestworldrecipes.data.local.LocalDataSource
+import com.sandoval.bestworldrecipes.data.remote.RemoteDataSource
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import javax.inject.Inject
 
 @ActivityRetainedScoped
 class Repository @Inject constructor(
-    remoteDataSource: RemoteDataSource
+    remoteDataSource: RemoteDataSource,
+    localDataSource: LocalDataSource
 ) {
 
     val remoteDataSource = remoteDataSource
-
+    val localDataSource = localDataSource
 
 }

--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/database/RecipesDatabase.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/database/RecipesDatabase.kt
@@ -1,0 +1,19 @@
+package com.sandoval.bestworldrecipes.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.sandoval.bestworldrecipes.data.database.dao.RecipesDao
+import com.sandoval.bestworldrecipes.data.database.entity.RecipesEntity
+
+@Database(
+    entities = [RecipesEntity::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(RecipesTypeConverter::class)
+abstract class RecipesDatabase : RoomDatabase() {
+
+    abstract fun recipesDao(): RecipesDao
+
+}

--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/database/RecipesTypeConverter.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/database/RecipesTypeConverter.kt
@@ -1,0 +1,28 @@
+package com.sandoval.bestworldrecipes.data.database
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.sandoval.bestworldrecipes.data.models.FoodRecipe
+
+
+class RecipesTypeConverter {
+
+    var gson = Gson()
+
+    //FoodRecipe to String
+    @TypeConverter
+    fun foodRecipeToString(foodRecipe: FoodRecipe): String {
+        return gson.toJson(foodRecipe)
+    }
+
+
+    //String to FoodRecipe
+    @TypeConverter
+    fun stringToFoodRecipe(data: String): FoodRecipe {
+        val listType = object : TypeToken<FoodRecipe>() {}.type
+        return gson.fromJson(data, listType)
+    }
+
+
+}

--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/database/dao/RecipesDao.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/database/dao/RecipesDao.kt
@@ -1,0 +1,18 @@
+package com.sandoval.bestworldrecipes.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.sandoval.bestworldrecipes.data.database.entity.RecipesEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RecipesDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRecipes(recipesEntity: RecipesEntity)
+
+    @Query("SELECT * FROM recipes_table ORDER BY id ASC")
+    fun readRecipes(): Flow<List<RecipesEntity>>
+}

--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/database/entity/RecipesEntity.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/database/entity/RecipesEntity.kt
@@ -1,0 +1,14 @@
+package com.sandoval.bestworldrecipes.data.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.sandoval.bestworldrecipes.data.models.FoodRecipe
+import com.sandoval.bestworldrecipes.utils.Constants.Companion.RECIPES_TABLE
+
+@Entity(tableName = RECIPES_TABLE)
+class RecipesEntity(
+    var foodRecipe: FoodRecipe
+) {
+    @PrimaryKey(autoGenerate = false)
+    var id: Int = 0
+}

--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/local/LocalDataSource.kt
@@ -1,0 +1,18 @@
+package com.sandoval.bestworldrecipes.data.local
+
+import com.sandoval.bestworldrecipes.data.database.dao.RecipesDao
+import com.sandoval.bestworldrecipes.data.database.entity.RecipesEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class LocalDataSource @Inject constructor(
+    private val recipesDao: RecipesDao
+) {
+    fun readRecipes(): Flow<List<RecipesEntity>> {
+        return recipesDao.readRecipes()
+    }
+
+    suspend fun insertRecipes(recipesEntity: RecipesEntity) {
+        recipesDao.insertRecipes(recipesEntity)
+    }
+}

--- a/app/src/main/java/com/sandoval/bestworldrecipes/data/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/data/remote/RemoteDataSource.kt
@@ -1,4 +1,4 @@
-package com.sandoval.bestworldrecipes.data
+package com.sandoval.bestworldrecipes.data.remote
 
 import com.sandoval.bestworldrecipes.data.models.FoodRecipe
 import com.sandoval.bestworldrecipes.data.network.FoodRecipesApi

--- a/app/src/main/java/com/sandoval/bestworldrecipes/di/DatabaseModule.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/di/DatabaseModule.kt
@@ -1,0 +1,33 @@
+package com.sandoval.bestworldrecipes.di
+
+import android.content.Context
+import androidx.room.Room
+import com.sandoval.bestworldrecipes.data.database.RecipesDatabase
+import com.sandoval.bestworldrecipes.utils.Constants.Companion.RECIPES_DATABASE
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Singleton
+    @Provides
+    fun provideDatabase(
+        @ApplicationContext context: Context
+    ) = Room.databaseBuilder(
+        context,
+        RecipesDatabase::class.java,
+        RECIPES_DATABASE
+    ).build()
+
+    @Singleton
+    @Provides
+    fun provideDao(
+        database: RecipesDatabase
+    ) = database.recipesDao()
+}

--- a/app/src/main/java/com/sandoval/bestworldrecipes/utils/Constants.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/utils/Constants.kt
@@ -7,12 +7,16 @@ class Constants {
         const val API_KEY = "[TYPE_YOUR_API_KEY_HERE]"
         const val URL_BASE = "https://api.spoonacular.com"
 
-        //
+        // API Queries keys
         const val QUERY_API_KEY = "apiKey"
         const val QUERY_NUMBER = "number"
         const val QUERY_TYPE = "type"
         const val QUERY_DIET = "diet"
         const val QUERY_ADD_RECIPE_INFORMATION = "addRecipeInformation"
         const val QUERY_FILL_INGREDIENTS = "fillIngredients"
+
+        //ROOM Database
+        const val RECIPES_DATABASE = "recipes_database"
+        const val RECIPES_TABLE = "recipes_table"
     }
 }


### PR DESCRIPTION
 - Create DAO and Entity for Room persistance model
 - Create RecipesDatabase.kt to connect the entity and the dao to the app
 - Create LocalDataSource.kt for future usage to get the data persisted inside the DB
 - Add to Repository.kt the LocalDataSource.kt property
 - Create DatabaseModule.kt to be injected in the app
 - Added to the MainViewmodel.kt the ROOM DB scope and the offline cache handler to use in the RecipesFragment.kt
 - Use the Persisted data inside the UI if the DB is not empty, if is empty then call the API Data request