### PR TITLE
DiffUtil Refactor

### DIFF
--- a/app/src/main/java/com/sandoval/bestworldrecipes/utils/RecipesDiffUtil.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/utils/RecipesDiffUtil.kt
@@ -3,9 +3,9 @@ package com.sandoval.bestworldrecipes.utils
 import androidx.recyclerview.widget.DiffUtil
 import com.sandoval.bestworldrecipes.data.models.Result
 
-class RecipesDiffUtil(
-    private val oldRecipes: List<Result>,
-    private val newRecipes: List<Result>
+class RecipesDiffUtil<T>(
+    private val oldRecipes: List<T>,
+    private val newRecipes: List<T>
 ) : DiffUtil.Callback() {
 
 


### PR DESCRIPTION
 - RecipesDiffUtil.kt refactored: Before was using as an argument only Result.kt class. Now was refactored to be a generic class, so it can be implemented in any adapter created for future recycler views.

 For example: Now is being used inside the recipes fragment so we pass inside the diffutil the foodrecipes object, which has a list of Results.kt. On the other hand if we want to use the same diffutil inside the ingredients fragment, we can populate it with ExtendenIngredients, as this generic class receives any object. This works as a template.