### PR TITLE
Remove Favorite Recipe Saved

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,4 +83,5 @@
     <!--Favorite Recipes Strings-->
     <string name="saved_favorite_recipe_snackbar_message">Saved Recipe.</string>
     <string name="saved_favorite_recipe_snackbar_action">Okay</string>
+    <string name="remove_favorite_recipe_snackbar_message">Removed from favorites.</string>
 </resources>


### PR DESCRIPTION
   - Added to DetailsActivity.kt a method to remove a recipe that has already been saved inside the favorites_recipes_table into the db. If the recipe is saved, then when we press the start icon the recipe will be removed and turn into white again.