### PR TITLE
Long Click Favorite Recipe Contextual Action Mode

### DIFF
--- a/app/src/main/java/com/sandoval/bestworldrecipes/adapters/FavoriteRecipesAdapter.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/adapters/FavoriteRecipesAdapter.kt
@@ -1,17 +1,21 @@
 package com.sandoval.bestworldrecipes.adapters
 
-import android.view.LayoutInflater
-import android.view.ViewGroup
+import android.view.*
+import androidx.fragment.app.FragmentActivity
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.sandoval.bestworldrecipes.R
 import com.sandoval.bestworldrecipes.data.database.entity.FavoritesEntity
 import com.sandoval.bestworldrecipes.databinding.FavoriteRecipesRowLayoutBinding
 import com.sandoval.bestworldrecipes.ui.fragments.FavoritesRecipesFragmentDirections
 import com.sandoval.bestworldrecipes.utils.RecipesDiffUtil
-import kotlinx.android.synthetic.main.fragment_favorites_receipes.view.*
+import kotlinx.android.synthetic.main.favorite_recipes_row_layout.view.*
 
-class FavoriteRecipesAdapter : RecyclerView.Adapter<FavoriteRecipesAdapter.MyViewHolder>() {
+class FavoriteRecipesAdapter(
+    private val requireActivity: FragmentActivity
+) : RecyclerView.Adapter<FavoriteRecipesAdapter.MyViewHolder>(),
+    ActionMode.Callback {
 
     private var favoriteRecipes = emptyList<FavoritesEntity>()
 
@@ -32,6 +36,14 @@ class FavoriteRecipesAdapter : RecyclerView.Adapter<FavoriteRecipesAdapter.MyVie
                     selectedRecipe.result
                 )
             holder.itemView.findNavController().navigate(action)
+        }
+
+        /**
+         * Long Click Listener
+         */
+        holder.itemView.favoriteRecipesRowLayout.setOnLongClickListener {
+            requireActivity.startActionMode(this)
+            true
         }
     }
 
@@ -60,5 +72,22 @@ class FavoriteRecipesAdapter : RecyclerView.Adapter<FavoriteRecipesAdapter.MyVie
         val diffUtilResult = DiffUtil.calculateDiff(favoriteRecipesDiffUtil)
         favoriteRecipes = newFavoriteRecipes
         diffUtilResult.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateActionMode(actionMode: ActionMode?, menu: Menu?): Boolean {
+        actionMode?.menuInflater?.inflate(R.menu.favorite_recipes_menu, menu)
+        return true
+    }
+
+    override fun onPrepareActionMode(actionMode: ActionMode?, menu: Menu?): Boolean {
+        return true
+    }
+
+    override fun onActionItemClicked(actionMode: ActionMode?, item: MenuItem?): Boolean {
+        return true
+    }
+
+    override fun onDestroyActionMode(actionMode: ActionMode?) {
+
     }
 }

--- a/app/src/main/java/com/sandoval/bestworldrecipes/ui/fragments/FavoritesRecipesFragment.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/ui/fragments/FavoritesRecipesFragment.kt
@@ -15,7 +15,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class FavoritesRecipesFragment : Fragment() {
 
-    private val mAdapter: FavoriteRecipesAdapter by lazy { FavoriteRecipesAdapter() }
+    private val mAdapter: FavoriteRecipesAdapter by lazy { FavoriteRecipesAdapter(requireActivity()) }
     private val mainViewModel: MainViewModel by viewModels()
 
     private var _binding: FragmentFavoritesReceipesBinding? = null
@@ -39,11 +39,6 @@ class FavoritesRecipesFragment : Fragment() {
 
         return binding.root
 
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.favorite_recipes_menu, menu)
-        super.onCreateOptionsMenu(menu, inflater)
     }
 
     private fun setupFavoriteRecipesRecyclerView(recyclerView: RecyclerView) {


### PR DESCRIPTION
   - Modify FavoriteRecipesAdapter.kt to extend ActionMode Callback to create contextual menu after the Favorite Recipe is long clicked
   - Delete from FavoritesRecipesFragment.kt the menu to be painted and add to the adapter the parameter requireActivity to activate the contextual action mode after long click in Favorite Recipe