### PR TITLE
Close Contextual Action Mode

### DIFF
--- a/app/src/main/java/com/sandoval/bestworldrecipes/adapters/FavoriteRecipesAdapter.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/adapters/FavoriteRecipesAdapter.kt
@@ -14,6 +14,7 @@ import com.sandoval.bestworldrecipes.ui.fragments.FavoritesRecipesFragmentDirect
 import com.sandoval.bestworldrecipes.utils.RecipesDiffUtil
 import com.sandoval.bestworldrecipes.viewmodels.MainViewModel
 import kotlinx.android.synthetic.main.favorite_recipes_row_layout.view.*
+import java.util.*
 
 class FavoriteRecipesAdapter(
     private val requireActivity: FragmentActivity,
@@ -114,7 +115,7 @@ class FavoriteRecipesAdapter(
             selectedRecipes.forEach {
                 mainViewModel.deleteFavoriteRecipe(it)
             }
-            showSnackBar("${selectedRecipes.size} Recipe/s removed.")
+            showSnackBar("${selectedRecipes.size} ${requireActivity.getString(R.string.favorite_recipes_item_removed_snackbar)}")
             multiSelection = false
             selectedRecipes.clear()
             actionMode?.finish()
@@ -190,7 +191,14 @@ class FavoriteRecipesAdapter(
             rootView,
             message,
             Snackbar.LENGTH_LONG
-        ).setAction("Okay") {}
+        )
+            .setAction((requireActivity.getString(R.string.snackbar_action_okay)).lowercase(Locale.getDefault())) {}
             .show()
+    }
+
+    fun clearContextualActionMode() {
+        if (this::mActionMode.isInitialized) {
+            mActionMode.finish()
+        }
     }
 }

--- a/app/src/main/java/com/sandoval/bestworldrecipes/ui/fragments/FavoritesRecipesFragment.kt
+++ b/app/src/main/java/com/sandoval/bestworldrecipes/ui/fragments/FavoritesRecipesFragment.kt
@@ -6,7 +6,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.sandoval.bestworldrecipes.R
 import com.sandoval.bestworldrecipes.adapters.FavoriteRecipesAdapter
 import com.sandoval.bestworldrecipes.databinding.FragmentFavoritesReceipesBinding
 import com.sandoval.bestworldrecipes.viewmodels.MainViewModel
@@ -54,5 +53,6 @@ class FavoritesRecipesFragment : Fragment() {
     override fun onDestroy() {
         super.onDestroy()
         _binding = null
+        mAdapter.clearContextualActionMode()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,6 @@
     <string name="favorites_recipes_menu_delete_all_favorites">Delete all</string>
     <string name="favorite_recipes_one_item_selected"> item selected</string>
     <string name="favorite_recipes_more_items_selected"> items selected</string>
+    <string name="favorite_recipes_item_removed_snackbar"> Recipe/s removed.</string>
+    <string name="snackbar_action_okay">Okay.</string>
 </resources>


### PR DESCRIPTION
  - Add method to close the contextual action mode inside FavoriteRecipesAdapter when navigation through bottom navigation is triggered
  - Use the method to close contextual action mode inside onDestroy of FavoriteRecipesFragment
  - Add new strings to handle messages of snackbar